### PR TITLE
Add  git pull before you push

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ We will start with using the parameters that are **required** and later implemen
    ```shell
    git add action.yml
    git commit -m 'create action.yml'
-   git push
+   git pull;git push
    ```
 5. Wait about 20 seconds then refresh this page for the next step.
 
@@ -216,7 +216,7 @@ Our action does not require much metadata for it to run correctly. We will not b
    ```shell
    git add action.yml
    git commit -m 'add metadata for the joke action'
-   git push
+   git pull;git push
    ```
 4. Wait about 20 seconds then refresh this page for the next step.
 
@@ -379,7 +379,7 @@ _Don't forget to call the `run()` function._
    ```shell
    git add joke.js main.js
    git commit -m 'creating joke.js and main.js'
-   git push
+   git pull;git push
    ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ Our action does not require much metadata for it to run correctly. We will not b
    ```shell
    git add action.yml
    git commit -m 'add metadata for the joke action'
-   git pull;git push
+   git pull
+   git push
    ```
 4. Wait about 20 seconds then refresh this page for the next step.
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ We will start with using the parameters that are **required** and later implemen
    ```shell
    git add action.yml
    git commit -m 'create action.yml'
-   git pull;git push
+   git pull
+   git push
    ```
 5. Wait about 20 seconds then refresh this page for the next step.
 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,8 @@ _Don't forget to call the `run()` function._
    ```shell
    git add joke.js main.js
    git commit -m 'creating joke.js and main.js'
-   git pull;git push
+   git pull
+   git push
    ```
 
 </details>


### PR DESCRIPTION
### Why:

Closes [issue link]

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
Actions create a commit, which isn't pulled before the next push.

### Check off the following:

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
